### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,16 +1,16 @@
-ScaleManager		KEYWORD1
-Scale				KEYWORD1
-init				KEYWORD2
-setFundamental		KEYWORD2
-addScale			KEYWORD2
-setScale			KEYWORD2
+ScaleManager	KEYWORD1
+Scale	KEYWORD1
+init	KEYWORD2
+setFundamental	KEYWORD2
+addScale	KEYWORD2
+setScale	KEYWORD2
 getFundamentalName	KEYWORD2
-getScaleName		KEYWORD2
-getScaleNote		KEYWORD2
+getScaleName	KEYWORD2
+getScaleNote	KEYWORD2
 getScaleNoteFreq	KEYWORD2
 getScaleNotePeriod	KEYWORD2
 getScaleNoteName	KEYWORD2
 
-CHROMATIC 			LITERAL1
-MAJOR 				LITERAL1
-MINOR 				LITERAL1
+CHROMATIC	LITERAL1
+MAJOR	LITERAL1
+MINOR	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords